### PR TITLE
Bump the runtime version to nodejs12.x

### DIFF
--- a/ask-resources.json
+++ b/ask-resources.json
@@ -15,7 +15,7 @@
       },
       "skillInfrastructure": {
         "userConfig": {
-          "runtime": "nodejs10.x",
+          "runtime": "nodejs12.x",
           "handler": "index.handler",
           "templatePath": "./infrastructure/cfn-deployer/skill-stack.yaml",
           "awsRegion": "us-east-1"


### PR DESCRIPTION
Node.js 10 has been declared end of life as of April 30, 2021 and will no longer be supported by AWS on July 30, 2021. This change updates the default Node.js runtime to version 12.x.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
